### PR TITLE
ci(flakehub-publish-tagged.yml): add flakehub support to ci

### DIFF
--- a/.github/workflows/flakehub-publish-tagged.yml
+++ b/.github/workflows/flakehub-publish-tagged.yml
@@ -1,0 +1,27 @@
+name: "Publish tags to FlakeHub"
+on:
+  push:
+    tags:
+      - "v?[0-9]+.[0-9]+.[0-9]+*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "The existing tag to publish to FlakeHub"
+        type: "string"
+        required: true
+jobs:
+  flakehub-publish:
+    runs-on: "ubuntu-latest"
+    permissions:
+      id-token: "write"
+      contents: "read"
+    steps:
+      - uses: "actions/checkout@v3"
+        with:
+          ref: "${{ (inputs.tag != null) && format('refs/tags/{0}', inputs.tag) || '' }}"
+      - uses: "DeterminateSystems/nix-installer-action@main"
+      - uses: "DeterminateSystems/flakehub-push@main"
+        with:
+          visibility: "public"
+          name: "integrated-reasoning/napali"
+          tag: "${{ inputs.tag }}"

--- a/README.md
+++ b/README.md
@@ -1,9 +1,25 @@
 # Napali
 
 [![ci](https://github.com/integrated-reasoning/napali/actions/workflows/ci.yml/badge.svg)](https://github.com/integrated-reasoning/napali/actions/workflows/ci.yml)
+[![FlakeHub](https://img.shields.io/endpoint?url=https://flakehub.com/f/integrated-reasoning/napali/badge)](https://flakehub.com/flake/integrated-reasoning/napali)
 
 ## About
 
 Napali is a TUI interface to Integrated Reasoning's hardware-accelerated solver service. The TUI provides an environment for interacting with combinatorial optimization solvers and managing local and remote optimization workloads. Furthermore, Napali aims to facilitate modern development practices in operations research workflows.
 
 This developer preview release is intended for early adopters and has no solver related features enabled at this time.
+
+## Usage as a flake
+
+Add napali to your `flake.nix`:
+
+```nix
+{
+  inputs.napali.url = "https://flakehub.com/f/integrated-reasoning/napali/*.tar.gz";
+
+  outputs = { self, napali }: {
+    # Use in your outputs
+  };
+}
+
+```


### PR DESCRIPTION
Add a CI workflow to publish new tags to [FlakeHub](https://flakehub.com/). 